### PR TITLE
update security settings of favonia/cloudflare-ddns

### DIFF
--- a/cloudflare/docker-compose_ddns.yml
+++ b/cloudflare/docker-compose_ddns.yml
@@ -5,16 +5,15 @@ services:
     container_name: cloudflare-ddns
     #network_mode: host
     restart: always
+    #user: "1000:1000"
     cap_drop:
       - all
     read_only: true
     security_opt:
       - no-new-privileges:true
     environment:
-      #- PGID=1000
-      #- PUID=1000
       - CF_API_TOKEN=3d0a5d703e84b8899754804f88318a47c385a# pls adjust
       - DOMAINS=nanaoware.online # pls adjust; a list of fully qualified domain names separated by commas
-      - PROXIED=false # instructs Cloudflare to cache webpages on your machine and hide its actual IP addresses
+      - PROXIED=false # if true, instructs Cloudflare to cache webpages on your machine and hide its actual IP addresses
       - TZ=Europe/Berlin
       - IP6_PROVIDER=none # disbale IPv6


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16) (released on 16 July), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer, cleaner, and more reliable; but it requires an update to the configuration. In particular, the environment variables `PUID=uid` and `PGID=gid` should be replaced by `user: "uid:gid"` or `--user uid:gid`. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in the updater.

_PS:_ Did you accidentally commit your API token to this public repository? Perhaps you want to [roll the token](https://developers.cloudflare.com/fundamentals/api/how-to/roll-token/).